### PR TITLE
Add TimeSent field to ExecutedAction for more detail

### DIFF
--- a/database/init_db.sql
+++ b/database/init_db.sql
@@ -40,8 +40,9 @@ ALTER TABLE public."CallBack" OWNER TO hivemind;
 CREATE TABLE public."ExecutedActions" (
     "id" text NOT NULL,
     "UUIDofAction" text NOT NULL,
-    "TimeRan" text NOT NULL,
-    "Successful" boolean NOT NULL,
+    "TimeSent" text NOT NULL,
+    "TimeRan" text,
+    "Successful" boolean,
     "ActionResponse" text
 );
 
@@ -187,7 +188,7 @@ COPY public."CallBack" ("UUIDImplant", "FirstCall", "LastCall") FROM stdin;
 -- Data for Name: ExecutedActions; Type: TABLE DATA; Schema: public; Owner: hivemind
 --
 
-COPY public."ExecutedActions" (id, "UUIDofAction", "TimeRan", "Successful", "ActionResponse") FROM stdin;
+COPY public."ExecutedActions" (id, "UUIDofAction", "TimeSent", "TimeRan", "Successful", "ActionResponse") FROM stdin;
 \.
 
 

--- a/teamserver/pkg/comms/ActionRequest.go
+++ b/teamserver/pkg/comms/ActionRequest.go
@@ -46,15 +46,10 @@ func ActionRequestHandler(packet Packet) ([]Packet, error) {
 		return allPackets, nil
 	}
 
-	// packetCtr := len(stagedActions)
 	for i := 0; i < len(stagedActions); i++ {
-		// if packetCtr == 0 {
-		// 	break
-		// }
 
 		action, err := generateAction(stagedActions[i])
 		if err != nil {
-			// packetCtr--
 			continue
 		}
 
@@ -74,11 +69,9 @@ func ActionRequestHandler(packet Packet) ([]Packet, error) {
 		// MOVE STAGED TO EXECUTED HERE
 		d.DeleteStagedAction(stagedActions[i].Id)
 		executed := model.ExecutedActions{
-			Id:             stagedActions[i].Id,
-			UUIDofAction:   stagedActions[i].UUIDofAction,
-			TimeRan:        "",
-			Successful:     false,
-			ActionResponse: "",
+			Id:           stagedActions[i].Id,
+			UUIDofAction: stagedActions[i].UUIDofAction,
+			TimeSent:     time.Now().Format(crud.TimeStamp),
 		}
 		d.InsertExecutedAction(executed)
 	}

--- a/teamserver/pkg/comms/ActionResponse.go
+++ b/teamserver/pkg/comms/ActionResponse.go
@@ -32,6 +32,7 @@ func ActionResponseHandler(packet Packet) ([]Packet, error) {
 		return allPackets, err
 	}
 
+	// TODO: ADD ERROR CHECKING FROM IMPLANT
 	d.UpdateExecutedActionResponse(actionResp.ActionID, actionResp.Response)
 	d.UpdateExecutedActionSuccessful(actionResp.ActionID, true)
 	d.UpdateExecutedActionTimeRan(actionResp.ActionID, time.Now().Format(crud.TimeStamp))

--- a/teamserver/pkg/crud/ExecutedActions.go
+++ b/teamserver/pkg/crud/ExecutedActions.go
@@ -22,6 +22,7 @@ func (d *DatabaseModel) AllExecutedActions() ([]model.ExecutedActions, error) {
 		err = rows.Scan(
 			&executedAction.Id,
 			&executedAction.UUIDofAction,
+			&executedAction.TimeSent,
 			&executedAction.TimeRan,
 			&executedAction.Successful,
 			&executedAction.ActionResponse,
@@ -45,6 +46,7 @@ func (d *DatabaseModel) GetExecutedActionById(id string) (model.ExecutedActions,
 	err := row.Scan(
 		&executedAction.Id,
 		&executedAction.UUIDofAction,
+		&executedAction.TimeSent,
 		&executedAction.TimeRan,
 		&executedAction.Successful,
 		&executedAction.ActionResponse,
@@ -55,14 +57,15 @@ func (d *DatabaseModel) GetExecutedActionById(id string) (model.ExecutedActions,
 
 func (d *DatabaseModel) InsertExecutedAction(executedAction model.ExecutedActions) (bool, error) {
 	sqlStatement := `INSERT INTO public."ExecutedActions"(
-		id, "UUIDofAction", "TimeRan", "Successful", "ActionResponse")
-		VALUES ($1, $2, $3, $4, $5);`
+		id, "UUIDofAction", "TimeSent", "TimeRan", "Successful", "ActionResponse")
+		VALUES ($1, $2, $3, $4, $5, $6);`
 
 	check := true
 
 	_, err := d.db.Exec(sqlStatement,
 		executedAction.Id,
 		executedAction.UUIDofAction,
+		executedAction.TimeSent,
 		executedAction.TimeRan,
 		executedAction.Successful,
 		executedAction.ActionResponse)

--- a/teamserver/pkg/listeners/tcp/listener.go
+++ b/teamserver/pkg/listeners/tcp/listener.go
@@ -38,7 +38,6 @@ func handleConnection(conn net.Conn) {
 
 	bytes, err := comms.HandleMessage(msg[:n])
 	if err != nil {
-		// fmt.Println(err)
 		return
 	}
 

--- a/teamserver/pkg/model/model.go
+++ b/teamserver/pkg/model/model.go
@@ -67,6 +67,7 @@ type StoredActions struct {
 type ExecutedActions struct {
 	Id             string `json:"id"`
 	UUIDofAction   string `json:"uuidofaction"`
+	TimeSent       string `json:"timesent"`
 	TimeRan        string `json:"timeran"`
 	Successful     bool   `json:"successful"`
 	ActionResponse string `json:"actionresponse"`


### PR DESCRIPTION
This PR adds the `TimeSent` field into the `ExecutedAction` data structure. The purpose of this is to allow for the teamserver to know how long ago that it sent the action out. With this field you will be able to tell as an operator if a command was sent out and never got back. Also, the operator will know if there was an unusually large delay in the response as well. 