### PR TITLE
Config file

### DIFF
--- a/scripts/adduser.sh
+++ b/scripts/adduser.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# This script currently adds a default admin user with default creds
+docker-compose exec -T postgres psql -U hivemind -d hivemind -c "INSERT INTO public.\"Operators\"(\"Username\", \"Password\", \"Permission\") VALUES ('admin', 'admin', 1);"
+

--- a/teamserver/cmd/hivemind/server.go
+++ b/teamserver/cmd/hivemind/server.go
@@ -1,11 +1,28 @@
 package main
 
 import (
+	"github.com/ProjectHivemind/Teamserver/teamserver/pkg/conf"
 	"github.com/ProjectHivemind/Teamserver/teamserver/pkg/listeners/tcp"
 	"github.com/ProjectHivemind/Teamserver/teamserver/pkg/rest"
 )
 
 func main() {
-	go tcp.StartListener("1234")
-	rest.Start("4321")
+	var configOptions conf.ConfOptions
+	configOptions.GetConf("../../config/config.yaml")
+
+	// Start the different listeners
+	for _, val := range configOptions.Listeners {
+		for k, v := range val {
+			switch k {
+			case "tcp":
+				if v["enabled"] == "true" {
+					go tcp.StartListener(v["port"])
+				}
+			default:
+				break
+			}
+		}
+	}
+
+	rest.Start(configOptions.Restapi["port"])
 }

--- a/teamserver/config/config.yaml
+++ b/teamserver/config/config.yaml
@@ -1,0 +1,23 @@
+# Teamserver config
+# The teamserver uses this config file to get up listeners and ports
+
+database:
+  uri: "localhost"
+  port: "5432"
+
+restapi:
+  port: "4321"
+
+# For more than one of the same type of listener on a different port, just add one
+# as the example commented out below does
+listeners:
+  - tcp:
+      enabled: "true"
+      port: "1234"
+  # Example of adding another TCP listener on a different port
+  # - tcp:
+  #     enabled: "true"
+  #     port: "12345"
+  - udp:
+      enabled: "false"
+      port: "0"

--- a/teamserver/go.mod
+++ b/teamserver/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/google/uuid v1.2.0
 	github.com/gorilla/mux v1.8.0
 	github.com/lib/pq v1.9.0
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )

--- a/teamserver/go.sum
+++ b/teamserver/go.sum
@@ -4,3 +4,6 @@ github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/lib/pq v1.9.0 h1:L8nSXQQzAYByakOFMTwpjRoHsMJklur4Gi59b6VivR8=
 github.com/lib/pq v1.9.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/teamserver/pkg/conf/config.go
+++ b/teamserver/pkg/conf/config.go
@@ -1,0 +1,27 @@
+package conf
+
+import (
+	"io/ioutil"
+	"log"
+
+	"gopkg.in/yaml.v3"
+)
+
+type ConfOptions struct {
+	Database  map[string]string              `yaml:"database"`
+	Restapi   map[string]string              `yaml:"restapi"`
+	Listeners []map[string]map[string]string `yaml:"listeners"`
+}
+
+func (c *ConfOptions) GetConf(path string) {
+	yamlFile, err := ioutil.ReadFile(path)
+	if err != nil {
+		log.Printf("yamlFile.Get err   #%v ", err)
+		return
+	}
+
+	err = yaml.Unmarshal(yamlFile, &c)
+	if err != nil {
+		log.Fatalf("Unmarshal: %v", err)
+	}
+}


### PR DESCRIPTION
This config file makes it easy for the teamserver to be set up with a config file. You can spin up as many listeners as you would like with it as well as set ports for other services. 